### PR TITLE
Use official release drafter, as a standalone workflow, without delay

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,12 @@
+---
+name: Release Drafter
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  workflows:
+    uses: homeassistant-apps/workflows/.github/workflows/release-drafter.yaml@main


### PR DESCRIPTION
# Proposed Changes

Should be merged after https://github.com/homeassistant-apps/workflows/pull/33 is merged.

## Related Issues

